### PR TITLE
fix KSCrash memory leak

### DIFF
--- a/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/KSCrashCachedData.c
+++ b/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/KSCrashCachedData.c
@@ -126,6 +126,12 @@ static void updateThreadList()
         }
         free(allQueueNames);
     }
+    
+    for (mach_msg_type_number_t i = 0; i < allThreadsCount; i++)
+    {
+        mach_port_deallocate(mach_task_self(), threads[i]);
+    }
+    vm_deallocate(mach_task_self(), (vm_address_t)threads, sizeof(thread_t) * allThreadsCount);
 }
 
 static void* monitorCachedData(__unused void* const userData)


### PR DESCRIPTION
KSCrash polls and logs data in a thread loop, but `task_threads` allocating memory from the kernel will cause memory leak.