### PR TITLE
FrameTracer and FrameDecorator use a new handler thread

### DIFF
--- a/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/tracer/FrameTracer.java
+++ b/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/tracer/FrameTracer.java
@@ -121,7 +121,7 @@ public class FrameTracer extends Tracer {
 
     private class FPSCollector extends IDoFrameListener {
 
-        private Handler frameHandler = new Handler(MatrixHandlerThread.getDefaultHandlerThread().getLooper());
+        private Handler frameHandler = new Handler(MatrixHandlerThread.getNewHandlerThread("frametracker").getLooper());
         private HashMap<String, FrameCollectItem> map = new HashMap<>();
 
         @Override

--- a/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/view/FrameDecorator.java
+++ b/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/view/FrameDecorator.java
@@ -188,7 +188,7 @@ public class FrameDecorator extends IDoFrameListener implements IAppForeground {
     @Override
     public Handler getHandler() {
         if (handler == null || !handler.getLooper().getThread().isAlive()) {
-            handler = new Handler(MatrixHandlerThread.getDefaultHandlerThread().getLooper());
+            handler = new Handler(MatrixHandlerThread.getNewHandlerThread("framedecorator").getLooper());
         }
         return handler;
     }


### PR DESCRIPTION
Default thread handle may be block when resource canary  is start, and FrameTracer and FrameDecorator can't receive frame callback.