### PR TITLE
Use a new handler thread for activity ref watcher

### DIFF
--- a/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/watcher/ActivityRefWatcher.java
+++ b/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/watcher/ActivityRefWatcher.java
@@ -132,7 +132,7 @@ public class ActivityRefWatcher extends FilePublisher implements Watcher {
         this.mResourcePlugin = resourcePlugin;
         final ResourceConfig config = resourcePlugin.getConfig();
         final Context context = app;
-        HandlerThread handlerThread = MatrixHandlerThread.getDefaultHandlerThread();
+        HandlerThread handlerThread = MatrixHandlerThread.getNewHandlerThread("activity_ref_watcher_thread");
         mDetectExecutor = componentFactory.createDetectExecutor(config, handlerThread);
         mMaxRedetectTimes = config.getMaxRedetectTimes();
         mDumpStorageManager = componentFactory.createDumpStorageManager(context);


### PR DESCRIPTION
ActivityRefWatcher use the default handler thread can block other code(FrameTracker...), should use a new handler thread .