### PR TITLE
fix:lazy initilaze defualtHandler and make sure defaultHandler is ini…

### DIFF
--- a/matrix/matrix-android/matrix-android-lib/src/main/java/com/tencent/matrix/util/MatrixHandlerThread.java
+++ b/matrix/matrix-android/matrix-android-lib/src/main/java/com/tencent/matrix/util/MatrixHandlerThread.java
@@ -60,7 +60,6 @@ public class MatrixHandlerThread {
             if (null == defaultHandlerThread) {
                 defaultHandlerThread = new HandlerThread(MATRIX_THREAD_NAME);
                 defaultHandlerThread.start();
-                defaultHandler = new Handler(defaultHandlerThread.getLooper());
                 defaultHandlerThread.getLooper().setMessageLogging(isDebug ? new LooperPrinter() : null);
                 MatrixLog.w(TAG, "create default handler thread, we should use these thread normal, isDebug:%s", isDebug);
             }
@@ -69,6 +68,13 @@ public class MatrixHandlerThread {
     }
 
     public static Handler getDefaultHandler() {
+        if (null == defaultHandler) {
+            synchronized (MatrixHandlerThread.class) {
+                if (null == defaultHandler) {
+                    defaultHandler = new Handler(getDefaultHandlerThread().getLooper());
+                }
+            }
+        }
         return defaultHandler;
     }
 


### PR DESCRIPTION
在只开启了StartupTracer的情况下，由于getDefaultHandlerThread没有被调用过，因此defaultHandler为null，此时在StartupTracer中使用getDefaultHandler().post(..)会导致空指针。

因此将defaultHandler的初始化移动到 getDefaultHandler方法中。