### PR TITLE
Fix implementation of hwtime

### DIFF
--- a/matrix/matrix-android/matrix-sqlite-lint/src/lemon/os_common.h
+++ b/matrix/matrix-android/matrix-sqlite-lint/src/lemon/os_common.h
@@ -67,7 +67,6 @@ static int last_page = 0;
 __inline__ unsigned long long int hwtime(void){
   unsigned long long int x;
   __asm__("rdtsc\n\t"
-          "mov %%edx, %%ecx\n\t"
           :"=A" (x));
   return x;
 }


### PR DESCRIPTION
In file matrix/matrix-android/matrix-sqlite-lint/src/lemon/os_common.h
line 70, the implementation of hwtime seems to invoke assembly
instruction `rdtsc` to get the cpu timestamp. From the specification of
x86, `rdtsc` will output timestamp to register `eax` and `edx`, which can be
written to a 64-bit variable by `asm("rdtsc":"=A"(x))` directly, the `mov
%%edx, %%ecx` is unused here, more than this, it may corrupt C variable
under some context, for example:
```
__inline__ unsigned long long int hwtime(void){
  unsigned long long int x;
  __asm__("rdtsc\n\t"
          "mov %%edx, %%ecx\n\t"
          :"=A" (x));
  return x;
}

int __attribute__((noinline)) set_val(int v) { return v; }

int main() {
  int a = set_val(0);
  int b = set_val(1);
  int c = set_val(2);
  a = a + b; b = b + c; c = c + a;
  uint64_t d = hwtime();
  printf("%d, %d, %d, %lx\n", a, b, c, d);
  return 0;
}
```
Assume rdtsc now is 0x23232323, the output should be 1, 3, 3, 23232323,
however the actual output on my PC (gcc-8 -O2) is 509053, 509055,
509055, 23232323, the first 3 numbers is random when execute.
The reason is that the extra instruction `mov %%edx, %%ecx` overrides
register `ecx`, this side effect is not realized by compiler (compiler will not
parse inline assembly code to get exact semantics), unknown side effect
results in incorrect schedule on register and cause C world breaks.