### PR TITLE
Do stack walk based on linked register when pc is null in KSCrash

### DIFF
--- a/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Tools/KSStackCursor_MachineContext.c
+++ b/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Tools/KSStackCursor_MachineContext.c
@@ -114,8 +114,9 @@ static bool advanceCursor(KSStackCursor *cursor)
         return false;
     }
     
-    if(context->instructionAddress == 0)
+    if(context->instructionAddress == 0 && cursor->state.currentDepth == 0)
     {
+        // Link register, if available, is the second address in the trace.
         context->instructionAddress = kscpu_instructionAddress(context->machineContext);
         if(context->instructionAddress == 0)
         {
@@ -123,6 +124,16 @@ static bool advanceCursor(KSStackCursor *cursor)
         }
         nextAddress = context->instructionAddress;
         goto successfulExit;
+    }
+    
+    if (context->linkRegister == 0 && !context->isPastFramePointer)
+    {
+        context->linkRegister = kscpu_linkRegister(context->machineContext);
+        if (context->linkRegister != 0)
+        {
+            nextAddress = context->linkRegister;
+            goto successfulExit;
+        }
     }
 
     if(context->currentFrame.previous == NULL)


### PR DESCRIPTION
When a crash happened due null ptr function, current logic will produce an empty stack trace. However, we can still walk from link register to get the rest of the stack trace. For more details, you can see in this [pull request](https://github.com/kstenerud/KSCrash/pull/356).