### PR TITLE
bugfix 修复裁剪后写入文件丢失字节的bug，bug会导致解析hprof文件失败。

### DIFF
--- a/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/hproflib/utils/IOUtil.java
+++ b/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/hproflib/utils/IOUtil.java
@@ -226,8 +226,8 @@ public final class IOUtil {
     }
 
     public static void writeString(OutputStream out, String text) throws IOException {
-        final int length = text.length();
-        out.write(text.getBytes(Charset.forName("UTF-8")), 0, length);
+        byte[] content=text.getBytes(Charset.forName("UTF-8"));
+        out.write(content, 0, content.length);
     }
 
     public static void writeNullTerminatedString(OutputStream out, String text) throws IOException {


### PR DESCRIPTION
遇到裁剪写入文件丢失字节的bug,导致解析hprof文件失败。
如果是多字节的UTF-8字符，这里当前写入是使用字符长度，而不是字节长度，会丢失字节。导致hprof文件格式错误。