### PR TITLE
fix when top activity resumed, no call dispatch foreground.

### DIFF
--- a/matrix/matrix-android/matrix-android-lib/src/main/java/com/tencent/matrix/AppActiveMatrixDelegate.java
+++ b/matrix/matrix-android/matrix-android-lib/src/main/java/com/tencent/matrix/AppActiveMatrixDelegate.java
@@ -127,8 +127,7 @@ public enum AppActiveMatrixDelegate {
 
         @Override
         public void onActivityStarted(Activity activity) {
-            updateScene(activity);
-            onDispatchForeground(getVisibleScene());
+
         }
 
 
@@ -152,7 +151,9 @@ public enum AppActiveMatrixDelegate {
 
         @Override
         public void onActivityResumed(Activity activity) {
-
+            // Consider the case of top activity state: pause to resume
+            updateScene(activity);
+            onDispatchForeground(getVisibleScene());
         }
 
         @Override


### PR DESCRIPTION
当 top Activity 从 pause 状态转成 resume 状态时，没有触发 `onForeground(true)` 的回调。