### PR TITLE
Fix potential crash due to race condition

### DIFF
--- a/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/CrashBlockPlugin/Main/BlockMonitor/Handler/WCPowerConsumeStackCollector.mm
+++ b/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/CrashBlockPlugin/Main/BlockMonitor/Handler/WCPowerConsumeStackCollector.mm
@@ -761,7 +761,9 @@ static float *g_cpuHighThreadValueArray = NULL;
             }
         }
         
-        ksmc_suspendEnvironment();
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
+        ksmc_suspendEnvironment(&threads, &numThreads);
         for (int i = 0; i < cost_cpu_thread_count; i++) {
             thread_t current_thread = cost_cpu_thread_list[i];
             uintptr_t backtrace_buffer[maxEntries];
@@ -780,7 +782,7 @@ static float *g_cpuHighThreadValueArray = NULL;
                 }
             }
         }
-        ksmc_resumeEnvironment();
+        ksmc_resumeEnvironment(threads, numThreads);
         
         for (int i = 0; i < cost_cpu_thread_count; i++) {
             if (async_stack_trace_array[i] != NULL && async_stack_trace_array_count[i] != 0) {

--- a/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -116,7 +116,10 @@ void my_cxa_throw(void* thrown_exception, std::type_info* tinfo, void (*dest)(vo
 
 static void CPPExceptionTerminate(void)
 {
-    ksmc_suspendEnvironment();
+    thread_act_array_t threads = NULL;
+    mach_msg_type_number_t numThreads = 0;
+    ksmc_suspendEnvironment(&threads, &numThreads);
+    
     KSLOG_DEBUG("Trapped c++ exception");
     const char* name = NULL;
     std::type_info* tinfo = __cxxabiv1::__cxa_current_exception_type();
@@ -190,14 +193,14 @@ catch(TYPE value)\
         ksTmpSingal.si_pid = (int)ksmc_getThreadFromContext(machineContext);
 
         kscm_handleException(crashContext);
-        ksmc_resumeEnvironment();
+        ksmc_resumeEnvironment(threads, numThreads);
         kscm_innerHandleSignal(&ksTmpSingal);
         kscm_handleSignal(&ksTmpSingal);
     }
     else
     {
         KSLOG_DEBUG("Detected NSException. Letting the current NSException handler deal with it.");
-        ksmc_resumeEnvironment();
+        ksmc_resumeEnvironment(threads, numThreads);
     }
 
 

--- a/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_Deadlock.m
+++ b/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_Deadlock.m
@@ -107,7 +107,9 @@ static NSTimeInterval g_watchdogInterval = 0;
 
 - (void) handleDeadlock
 {
-    ksmc_suspendEnvironment();
+    thread_act_array_t threads = NULL;
+    mach_msg_type_number_t numThreads = 0;
+    ksmc_suspendEnvironment(&threads, &numThreads);
     kscm_notifyFatalExceptionCaptured(false);
 
     KSMC_NEW_CONTEXT(machineContext);
@@ -127,7 +129,7 @@ static NSTimeInterval g_watchdogInterval = 0;
     crashContext->stackCursor = &stackCursor;
     
     kscm_handleException(crashContext);
-    ksmc_resumeEnvironment();
+    ksmc_resumeEnvironment(threads, numThreads);
 
     KSLOG_DEBUG(@"Calling abort()");
     abort();

--- a/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
+++ b/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
@@ -298,7 +298,9 @@ static void* handleExceptions(void* const userData)
                 exceptionMessage.code[0], exceptionMessage.code[1]);
     if(g_isEnabled)
     {
-        ksmc_suspendEnvironment();
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
+        ksmc_suspendEnvironment(&threads, &numThreads);
         g_isHandlingCrash = true;
         kscm_notifyFatalExceptionCaptured(true);
 
@@ -367,7 +369,7 @@ static void* handleExceptions(void* const userData)
 
         KSLOG_DEBUG("Crash handling complete. Restoring original handlers.");
         g_isHandlingCrash = false;
-        ksmc_resumeEnvironment();
+        ksmc_resumeEnvironment(threads, numThreads);
         kscm_innerHandleSignal(&ksTmpSingal);
         kscm_handleSignal(&ksTmpSingal);        
     }

--- a/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_NSException.m
+++ b/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_NSException.m
@@ -62,7 +62,9 @@ static void handleException(NSException* exception)
     KSLOG_DEBUG(@"Trapped exception %@", exception);
     if(g_isEnabled)
     {
-        ksmc_suspendEnvironment();
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
+        ksmc_suspendEnvironment(&threads, &numThreads);
         kscm_notifyFatalExceptionCaptured(false);
 
         KSLOG_DEBUG(@"Filling out context.");
@@ -97,7 +99,7 @@ static void handleException(NSException* exception)
 
         KSLOG_DEBUG(@"Calling main crash handler.");
         kscm_handleException(crashContext);
-        ksmc_resumeEnvironment();
+        ksmc_resumeEnvironment(threads, numThreads);
         kscm_innerHandleSignal(&ksTmpSingal);
         kscm_handleSignal(&ksTmpSingal);
 

--- a/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_Signal.c
+++ b/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_Signal.c
@@ -84,7 +84,9 @@ static void handleSignal(int sigNum, siginfo_t* signalInfo, void* userContext)
     KSLOG_DEBUG("Trapped signal %d", sigNum);
     if(g_isEnabled)
     {
-        ksmc_suspendEnvironment();
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
+        ksmc_suspendEnvironment(&threads, &numThreads);
         kscm_notifyFatalExceptionCaptured(false);
 
         KSLOG_DEBUG("Filling out context.");
@@ -105,7 +107,7 @@ static void handleSignal(int sigNum, siginfo_t* signalInfo, void* userContext)
         crashContext->stackCursor = &g_stackCursor;
 
         kscm_handleException(crashContext);
-        ksmc_resumeEnvironment();
+        ksmc_resumeEnvironment(threads, numThreads);
         kscm_innerHandleSignal(signalInfo);
         kscm_handleSignal(signalInfo);
     }

--- a/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_User.c
+++ b/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Monitors/KSCrashMonitor_User.c
@@ -55,9 +55,11 @@ void kscm_reportUserExceptionSelfDefinePath(const char* name,
     }
     else
     {
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
         if(logAllThreads)
         {
-            ksmc_suspendEnvironment();
+            ksmc_suspendEnvironment(&threads, &numThreads);
         }
         if(terminateProgram)
         {
@@ -91,7 +93,7 @@ void kscm_reportUserExceptionSelfDefinePath(const char* name,
         
         if(logAllThreads)
         {
-            ksmc_resumeEnvironment();
+            ksmc_resumeEnvironment(threads, numThreads);
         }
         if(terminateProgram)
         {
@@ -114,9 +116,11 @@ void kscm_reportUserException(const char* name,
     }
     else
     {
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
         if(logAllThreads)
         {
-            ksmc_suspendEnvironment();
+            ksmc_suspendEnvironment(&threads, &numThreads);
         }
         if(terminateProgram)
         {
@@ -149,7 +153,7 @@ void kscm_reportUserException(const char* name,
 
         if(logAllThreads)
         {
-            ksmc_resumeEnvironment();
+            ksmc_resumeEnvironment(threads, numThreads);
         }
         if(terminateProgram)
         {

--- a/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Tools/KSMachineContext.h
+++ b/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/KSCrash/Recording/Tools/KSMachineContext.h
@@ -34,14 +34,15 @@ extern "C" {
 
 #include "KSThread.h"
 #include <stdbool.h>
+#include <mach/mach.h>
 
 /** Suspend the runtime environment.
  */
-void ksmc_suspendEnvironment(void);
+void ksmc_suspendEnvironment(thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads);
 
 /** Resume the runtime environment.
  */
-void ksmc_resumeEnvironment(void);
+void ksmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_number_t numThreads);
 
 /** Create a new machine context on the stack.
  * This macro creates a storage object on the stack, as well as a pointer of type


### PR DESCRIPTION
We found some  crashes inside kscrash like the following
```
Exception Type: EXC_BAD_ACCESS ( SIGBUS )
Diagnosis: Attempted to dereference garbage pointer 0x14570808c.Originated at or in a subcall of unknown, cannot find symbol

0 | xxxxxx | ksmc_resumeEnvironment(KSMachineContext.c:231)
-- | -- | --
1 | xxxxxx | CPPExceptionTerminate()(KSCrashMonitor_CPPException.cpp:200)
2 | libc++abi.dylib | std::__terminate(void (*)())()
3 | libc++abi.dylib | ___cxa_throw()
4 | libobjc.A.dylib | _objc_exception_throw()
5 | Foundation | __NSOutOfMemoryErrorHandler()
6 | CoreFoundation | ___CFSafelyReallocate()
7 | Foundation | __NSMutableDataGrowBytes()
8 | Foundation | -[NSConcreteMutableData appendBytes:length:]()
9 | ImageIO | IIOImageWriteSession::putBytes(void const*, unsigned long)()
10 | ImageIO | write_fn(png_struct_def*, unsigned char*, unsigned long)()
11 | ImageIO | _png_write_chunk_data()
12 | ImageIO | __cg_png_write_complete_chunk()
13 | ImageIO | _png_compress_IDAT()
......
22 | libdispatch.dylib | __dispatch_call_block_and_release()
23 | libdispatch.dylib | __dispatch_client_callout()
24 | libdispatch.dylib | __dispatch_queue_override_invoke$VARIANT$armv81()
25 | libdispatch.dylib | __dispatch_root_queue_drain()
26 | libdispatch.dylib | __dispatch_worker_thread3()
27 | libsystem_pthread.dylib | __pthread_wqthread()
```
It seems the cause is a race condition where g_suspendedThreads was released while still being accessed. My solution is to save suspended threads in local variable instead of global variable, since suspend thread and resume thread are always called in pair.

