### PR TITLE
Fix performance trace inline asm in os_common.h

### DIFF
--- a/matrix/matrix-android/matrix-sqlite-lint/src/lemon/os_common.h
+++ b/matrix/matrix-android/matrix-sqlite-lint/src/lemon/os_common.h
@@ -66,7 +66,8 @@ static int last_page = 0;
 #ifdef SQLITE_PERFORMANCE_TRACE
 __inline__ unsigned long long int hwtime(void){
   unsigned long long int x;
-  __asm__("rdtsc\n\t"
+  __asm__ __volatile__(
+          "rdtsc\n\t"
           "mov %%edx, %%ecx\n\t"
           :"=A" (x));
   return x;


### PR DESCRIPTION
This commit fixes an inline assembly block that uses `rdtsc` instructin in order to trace the SQLite performance.

The issue is that the `__asm__` block is not marked as `__volatile__` and so an optimizing compiler (e.g. GCC 10.1 with -O3 compilation flag) may optimize out a second call to the `hwtime()` function, assuming it should return the same value.

This behavior is also described in GCC docs in https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html#Volatile after the following block:
> The following example demonstrates a case where you need to use the volatile qualifier. It uses the x86 rdtsc instruction, which reads the computer’s time-stamp counter. Without the volatile qualifier, the optimizers might assume that the asm block will always return the same value and therefore optimize away the second call.

The issue can also bee seen on https://godbolt.org/z/v_a-Qy