### PR TITLE
修复SwipeRefreshLayout空指针异常问题

### DIFF
--- a/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
+++ b/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
@@ -287,6 +287,7 @@ public final class ActivityLeakFixer {
         }
 
         iv.setImageDrawable(null);
+        recycleBitmap(d);
     }
 
     private static void recycleTextView(TextView tv) {
@@ -294,6 +295,7 @@ public final class ActivityLeakFixer {
         for (Drawable d : ds) {
             if (d != null) {
                 d.setCallback(null);
+                recycleBitmap(d);
             }
         }
         tv.setCompoundDrawables(null, null, null, null);
@@ -330,11 +332,13 @@ public final class ActivityLeakFixer {
         if (pd != null) {
             pb.setProgressDrawable(null);
             pd.setCallback(null);
+            recycleBitmap(pd);
         }
         final Drawable id = pb.getIndeterminateDrawable();
         if (id != null) {
             pb.setIndeterminateDrawable(null);
             id.setCallback(null);
+            recycleBitmap(id);
         }
     }
 
@@ -384,6 +388,7 @@ public final class ActivityLeakFixer {
             if (fg != null) {
                 fg.setCallback(null);
                 fl.setForeground(null);
+                recycleBitmap(fg);
             }
         }
     }
@@ -411,6 +416,7 @@ public final class ActivityLeakFixer {
             if (dd != null) {
                 dd.setCallback(null);
                 ll.setDividerDrawable(null);
+                recycleBitmap(dd);
             }
         }
     }
@@ -420,5 +426,15 @@ public final class ActivityLeakFixer {
         for (int i = 0; i < childCount; ++i) {
             unbindDrawablesAndRecycle(vg.getChildAt(i));
         }
+    }
+
+    private static void recycleBitmap(Drawable drawable){
+        if(drawable instanceof BitmapDrawable){
+            Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
+            if(!bitmap.isRecycled()){
+                bitmap.recycle();
+            }
+        }
+
     }
 }

--- a/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
+++ b/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
@@ -250,6 +250,10 @@ public final class ActivityLeakFixer {
             // Ignored.
         }
 
+        if (view instanceof SwipeRefreshLayout) {
+            return;
+        }
+
         if (view.getBackground() != null) {
             view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
                 @Override


### PR DESCRIPTION
fix #537
SwipeRefreshLayout在onDetachedFromWindow中会调用reset方法，在这个时候改变drawable的透明度，这个时候ActivityLeakFixer不应该回收SwipeRefreshLayout的drawable。