### PR TITLE
 修复SwipeRefreshLayout空指针异常

### DIFF
--- a/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
+++ b/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
@@ -296,7 +296,6 @@ public final class ActivityLeakFixer {
         }
 
         iv.setImageDrawable(null);
-        recycleBitmap(d);
     }
 
     private static void recycleTextView(TextView tv) {
@@ -304,7 +303,6 @@ public final class ActivityLeakFixer {
         for (Drawable d : ds) {
             if (d != null) {
                 d.setCallback(null);
-                recycleBitmap(d);
             }
         }
         tv.setCompoundDrawables(null, null, null, null);
@@ -341,13 +339,11 @@ public final class ActivityLeakFixer {
         if (pd != null) {
             pb.setProgressDrawable(null);
             pd.setCallback(null);
-            recycleBitmap(pd);
         }
         final Drawable id = pb.getIndeterminateDrawable();
         if (id != null) {
             pb.setIndeterminateDrawable(null);
             id.setCallback(null);
-            recycleBitmap(id);
         }
     }
 
@@ -397,7 +393,6 @@ public final class ActivityLeakFixer {
             if (fg != null) {
                 fg.setCallback(null);
                 fl.setForeground(null);
-                recycleBitmap(fg);
             }
         }
     }
@@ -425,7 +420,6 @@ public final class ActivityLeakFixer {
             if (dd != null) {
                 dd.setCallback(null);
                 ll.setDividerDrawable(null);
-                recycleBitmap(dd);
             }
         }
     }
@@ -437,13 +431,4 @@ public final class ActivityLeakFixer {
         }
     }
 
-    private static void recycleBitmap(Drawable drawable){
-        if(drawable instanceof BitmapDrawable){
-            Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
-            if(!bitmap.isRecycled()){
-                bitmap.recycle();
-            }
-        }
-
-    }
 }

--- a/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
+++ b/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
@@ -37,6 +37,7 @@ import com.tencent.matrix.util.MatrixLog;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import androidx.swiperefreshlayout.widget.CircularProgressDrawable;
 
 /**
  * Created by tangyinsheng on 2017/6/20.
@@ -250,6 +251,7 @@ public final class ActivityLeakFixer {
             // Ignored.
         }
 
+
         if (view.getBackground() != null) {
             view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
                 @Override
@@ -259,9 +261,16 @@ public final class ActivityLeakFixer {
 
                 @Override
                 public void onViewDetachedFromWindow(View v) {
+                    Drawable drawable = v.getDrawable();
+                    if (drawable instanceof CircularProgressDrawable) {
+                        v.removeOnAttachStateChangeListener(this);
+                        return;
+                    }
                     try {
-                        v.getBackground().setCallback(null);
-                        v.setBackgroundDrawable(null);
+                        if (drawable != null) {
+                            v.getBackground().setCallback(null);
+                            v.setBackgroundDrawable(null);
+                        }
                     } catch (Throwable ignored) {
                         // Ignored.
                     }

--- a/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
+++ b/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
@@ -287,6 +287,7 @@ public final class ActivityLeakFixer {
         }
 
         iv.setImageDrawable(null);
+        recycleBitmap(d);
     }
 
     private static void recycleTextView(TextView tv) {
@@ -294,6 +295,7 @@ public final class ActivityLeakFixer {
         for (Drawable d : ds) {
             if (d != null) {
                 d.setCallback(null);
+                recycleBitmap(d);
             }
         }
         tv.setCompoundDrawables(null, null, null, null);
@@ -330,11 +332,13 @@ public final class ActivityLeakFixer {
         if (pd != null) {
             pb.setProgressDrawable(null);
             pd.setCallback(null);
+            recycleBitmap(pd);
         }
         final Drawable id = pb.getIndeterminateDrawable();
         if (id != null) {
             pb.setIndeterminateDrawable(null);
             id.setCallback(null);
+            recycleBitmap(id);
         }
     }
 
@@ -384,6 +388,7 @@ public final class ActivityLeakFixer {
             if (fg != null) {
                 fg.setCallback(null);
                 fl.setForeground(null);
+                recycleBitmap(fg);
             }
         }
     }
@@ -411,6 +416,7 @@ public final class ActivityLeakFixer {
             if (dd != null) {
                 dd.setCallback(null);
                 ll.setDividerDrawable(null);
+                recycleBitmap(dd);
             }
         }
     }
@@ -420,5 +426,15 @@ public final class ActivityLeakFixer {
         for (int i = 0; i < childCount; ++i) {
             unbindDrawablesAndRecycle(vg.getChildAt(i));
         }
+    }
+
+    private static void recycleBitmap(Drawable drawable){
+        if(drawable instanceof BitmapDrawable){
+            Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
+            if(!bitmap.isRecycled()){
+                bitmap.recycle();
+            }
+        }
+
     }
 }


### PR DESCRIPTION
fix #541
SwipeRefreshLayout 的reset方法在onDetachedFromWindow和mRefreshListener的onAnimationEnd都会调用，
void reset() {
mCircleView.clearAnimation();
mProgress.stop();
mCircleView.setVisibility(View.GONE);
setColorViewAlpha(MAX_ALPHA);
// Return the circle to its start position
if (mScale) {
setAnimationProgress(0 /* animation complete and view is hidden */);
} else {
setTargetOffsetTopAndBottom(mOriginalOffsetTop - mCurrentTargetOffsetTop);
}
mCurrentTargetOffsetTop = mCircleView.getTop();
}

mCircleView.clearAnimation后会回调onAnimationEnd，所以可能出现一种情况在onDetachedFromWindow后回调了监听器或者其他过程调用reset，里面都用到的了setAlpha，如果ActivityLeakFixer清除drawable资源就会导致外部的SwipeRefreshLayout调用出现异常。
SwipeRefreshLayout 这个库只是更多时候希望重置drawable，没有想要设置为null，因此ActivityLeakFixer忽略跳过删除drawable会比较好。