### PR TITLE
修复Sample工程StartupTracer activity统计数量负数

### DIFF
--- a/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
+++ b/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
@@ -287,7 +287,6 @@ public final class ActivityLeakFixer {
         }
 
         iv.setImageDrawable(null);
-        recycleBitmap(d);
     }
 
     private static void recycleTextView(TextView tv) {
@@ -295,7 +294,6 @@ public final class ActivityLeakFixer {
         for (Drawable d : ds) {
             if (d != null) {
                 d.setCallback(null);
-                recycleBitmap(d);
             }
         }
         tv.setCompoundDrawables(null, null, null, null);
@@ -332,13 +330,11 @@ public final class ActivityLeakFixer {
         if (pd != null) {
             pb.setProgressDrawable(null);
             pd.setCallback(null);
-            recycleBitmap(pd);
         }
         final Drawable id = pb.getIndeterminateDrawable();
         if (id != null) {
             pb.setIndeterminateDrawable(null);
             id.setCallback(null);
-            recycleBitmap(id);
         }
     }
 
@@ -388,7 +384,6 @@ public final class ActivityLeakFixer {
             if (fg != null) {
                 fg.setCallback(null);
                 fl.setForeground(null);
-                recycleBitmap(fg);
             }
         }
     }
@@ -416,7 +411,6 @@ public final class ActivityLeakFixer {
             if (dd != null) {
                 dd.setCallback(null);
                 ll.setDividerDrawable(null);
-                recycleBitmap(dd);
             }
         }
     }
@@ -426,15 +420,5 @@ public final class ActivityLeakFixer {
         for (int i = 0; i < childCount; ++i) {
             unbindDrawablesAndRecycle(vg.getChildAt(i));
         }
-    }
-
-    private static void recycleBitmap(Drawable drawable){
-        if(drawable instanceof BitmapDrawable){
-            Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
-            if(!bitmap.isRecycled()){
-                bitmap.recycle();
-            }
-        }
-
     }
 }

--- a/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
+++ b/matrix/matrix-android/matrix-resource-canary/matrix-resource-canary-android/src/main/java/com/tencent/matrix/resource/ActivityLeakFixer.java
@@ -287,6 +287,7 @@ public final class ActivityLeakFixer {
         }
 
         iv.setImageDrawable(null);
+        recycleBitmap(d);
     }
 
     private static void recycleTextView(TextView tv) {
@@ -294,6 +295,7 @@ public final class ActivityLeakFixer {
         for (Drawable d : ds) {
             if (d != null) {
                 d.setCallback(null);
+                recycleBitmap(d);
             }
         }
         tv.setCompoundDrawables(null, null, null, null);
@@ -330,11 +332,13 @@ public final class ActivityLeakFixer {
         if (pd != null) {
             pb.setProgressDrawable(null);
             pd.setCallback(null);
+            recycleBitmap(pd);
         }
         final Drawable id = pb.getIndeterminateDrawable();
         if (id != null) {
             pb.setIndeterminateDrawable(null);
             id.setCallback(null);
+            recycleBitmap(id);
         }
     }
 
@@ -384,6 +388,7 @@ public final class ActivityLeakFixer {
             if (fg != null) {
                 fg.setCallback(null);
                 fl.setForeground(null);
+                recycleBitmap(fg);
             }
         }
     }
@@ -411,6 +416,7 @@ public final class ActivityLeakFixer {
             if (dd != null) {
                 dd.setCallback(null);
                 ll.setDividerDrawable(null);
+                recycleBitmap(dd);
             }
         }
     }
@@ -420,5 +426,15 @@ public final class ActivityLeakFixer {
         for (int i = 0; i < childCount; ++i) {
             unbindDrawablesAndRecycle(vg.getChildAt(i));
         }
+    }
+
+    private static void recycleBitmap(Drawable drawable){
+        if(drawable instanceof BitmapDrawable){
+            Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
+            if(!bitmap.isRecycled()){
+                bitmap.recycle();
+            }
+        }
+
     }
 }

--- a/samples/sample-android/app/src/main/java/sample/tencent/matrix/trace/TestTraceMainActivity.java
+++ b/samples/sample-android/app/src/main/java/sample/tencent/matrix/trace/TestTraceMainActivity.java
@@ -49,16 +49,23 @@ public class TestTraceMainActivity extends Activity implements IAppForeground {
     private static final int PERMISSION_REQUEST_CODE = 0x02;
 
     @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.test_trace);
-        IssueFilter.setCurrentFilter(IssueFilter.ISSUE_TRACE);
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(newBase);
 
+        // If this is the first time you call this function in activity,you should call it before onCreate
         Plugin plugin = Matrix.with().getPluginByClass(TracePlugin.class);
         if (!plugin.isPluginStarted()) {
             MatrixLog.i(TAG, "plugin-trace start");
             plugin.start();
         }
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.test_trace);
+        IssueFilter.setCurrentFilter(IssueFilter.ISSUE_TRACE);
+
         decorator = FrameDecorator.getInstance(this);
         if (!canDrawOverlays()) {
             requestWindowPermission();


### PR DESCRIPTION
fix:#628
activeActivityCount++ 在StartupTracer的onAlive中注册activity生命周期后，onActivityCreate回调后才生效
所以第一次启动不应该在onCreate中启动，而是要在onCreate之前的生命周期启动activity数量才不为0