### PR TITLE
add file extension for apksigner&zipalign in Windows

### DIFF
--- a/samples/sample-android/app/build.gradle
+++ b/samples/sample-android/app/build.gradle
@@ -165,8 +165,8 @@ matrix {
         sevenZipPath = "${project.configurations.sevenZipDependency.resolve().getAt(0).getAbsolutePath()}"
         //Notice: You need to modify the  value of $apksignerPath on different platform. the value below only suitable for Mac Platform,
         //if on Windows, you may have to  replace apksigner with apksigner.bat.
-        apksignerPath = "${android.getSdkDirectory().getAbsolutePath()}/build-tools/${android.getBuildToolsVersion()}/apksigner"
-        zipAlignPath = "${android.getSdkDirectory().getAbsolutePath()}/build-tools/${android.getBuildToolsVersion()}/zipalign"
+        apksignerPath = "${android.getSdkDirectory().getAbsolutePath()}/build-tools/${android.getBuildToolsVersion()}/apksigner${isWindows() ? ".bat" : ""}"
+        zipAlignPath = "${android.getSdkDirectory().getAbsolutePath()}/build-tools/${android.getBuildToolsVersion()}/zipalign${isWindows() ? ".exe" : ""}"
         ignoreResources = ["R.id.*", "R.bool.*", "R.layout.unused_layout"]
     }
 }
@@ -184,5 +184,14 @@ project.tasks.whenTaskAdded {
                 }
             }
         }
+    }
+}
+
+def isWindows() {
+    try {
+        String os = System.getProperty("os.name").toLowerCase()
+        return os.indexOf("win") >= 0
+    } catch (Exception ignored) {
+        return false
     }
 }


### PR DESCRIPTION
异常类型：/samples/sample-android 在 Windows 构建失败

matrix版本：2.0.2

gradle版本：4.1.0

问题描述：构建时报 apksigner&zipalign 不存在
