### PR TITLE
[bugFix]Android Q机器上面需要requestLegacyExternalStorage属性才能访问非沙箱数据

### DIFF
--- a/samples/sample-android/app/src/main/AndroidManifest.xml
+++ b/samples/sample-android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity android:name=".MainActivity">


### PR DESCRIPTION
在 Android 10的机器上面，sample获取不到 Download目录下的读写权限，IO Canary无法测试。需要加上requestLegacyExternalStorage属性才能正常测试 IO