### PR TITLE
trace-canary UIThreadMonitor class add support to android api level 23+(android 6.0+)

### DIFF
--- a/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/listeners/IDoFrameListener.java
+++ b/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/listeners/IDoFrameListener.java
@@ -44,7 +44,9 @@ public class IDoFrameListener {
         public long intendedFrameTimeNs;
         public long inputCostNs;
         public long animationCostNs;
+        public long insetsAnimationCostNs;
         public long traversalCostNs;
+        public long commitCostNs;
 
         public void recycle() {
             if (sPool.size() <= 1000) {
@@ -56,7 +58,9 @@ public class IDoFrameListener {
                 this.intendedFrameTimeNs = 0;
                 this.inputCostNs = 0;
                 this.animationCostNs = 0;
+                this.insetsAnimationCostNs = 0;
                 this.traversalCostNs = 0;
+                this.commitCostNs = 0;
                 synchronized (sPool) {
                     sPool.add(this);
                 }
@@ -86,8 +90,8 @@ public class IDoFrameListener {
     }
 
     @CallSuper
-    public void collect(String focusedActivity, long startNs, long endNs, int dropFrame, boolean isVsyncFrame,
-                        long intendedFrameTimeNs, long inputCostNs, long animationCostNs, long traversalCostNs) {
+    public void collect(String focusedActivity, long startNs, long endNs, int dropFrame, boolean isVsyncFrame, long intendedFrameTimeNs,
+                        long inputCostNs, long animationCostNs, long insetsAnimationCostNs, long traversalCostNs, long commitCostNs) {
         FrameReplay replay = FrameReplay.create();
         replay.focusedActivity = focusedActivity;
         replay.startNs = startNs;
@@ -97,7 +101,9 @@ public class IDoFrameListener {
         replay.intendedFrameTimeNs = intendedFrameTimeNs;
         replay.inputCostNs = inputCostNs;
         replay.animationCostNs = animationCostNs;
+        replay.insetsAnimationCostNs = insetsAnimationCostNs;
         replay.traversalCostNs = traversalCostNs;
+        replay.commitCostNs = commitCostNs;
         list.add(replay);
         if (list.size() >= intervalFrame && getExecutor() != null) {
             final List<FrameReplay> copy = new LinkedList<>(list);
@@ -126,14 +132,14 @@ public class IDoFrameListener {
 
     @CallSuper
     public void doFrameAsync(String focusedActivity, long startNs, long endNs, int dropFrame, boolean isVsyncFrame,
-                             long intendedFrameTimeNs, long inputCostNs, long animationCostNs, long traversalCostNs) {
+                             long intendedFrameTimeNs, long inputCostNs, long animationCostNs, long insetsAnimationCostNs, long traversalCostNs, long commitCostNs) {
         long cost = (endNs - intendedFrameTimeNs) / Constants.TIME_MILLIS_TO_NANO;
         doFrameAsync(focusedActivity, cost, cost, dropFrame, isVsyncFrame);
     }
 
     @CallSuper
     public void doFrameSync(String focusedActivity, long startNs, long endNs, int dropFrame, boolean isVsyncFrame,
-                            long intendedFrameTimeNs, long inputCostNs, long animationCostNs, long traversalCostNs) {
+                            long intendedFrameTimeNs, long inputCostNs, long animationCostNs, long insetsAnimationCostNs, long traversalCostNs, long commitCostNs) {
         long cost = (endNs - intendedFrameTimeNs) / Constants.TIME_MILLIS_TO_NANO;
         doFrameSync(focusedActivity, cost, cost, dropFrame, isVsyncFrame);
     }

--- a/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/listeners/LooperObserver.java
+++ b/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/listeners/LooperObserver.java
@@ -27,7 +27,8 @@ public abstract class LooperObserver {
         isDispatchBegin = true;
     }
 
-    public void doFrame(String focusedActivity, long startNs, long endNs, boolean isVsyncFrame, long intendedFrameTimeNs, long inputCostNs, long animationCostNs, long traversalCostNs) {
+    public void doFrame(String focusedActivity, long startNs, long endNs, boolean isVsyncFrame, long intendedFrameTimeNs,
+                        long inputCostNs, long animationCostNs, long insetsAnimationCostNs, long traversalCostNs, long commitCostNs) {
 
     }
 

--- a/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/tracer/FrameTracer.java
+++ b/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/tracer/FrameTracer.java
@@ -123,9 +123,11 @@ public class FrameTracer extends Tracer implements Application.ActivityLifecycle
     }
 
     @Override
-    public void doFrame(String focusedActivity, long startNs, long endNs, boolean isVsyncFrame, long intendedFrameTimeNs, long inputCostNs, long animationCostNs, long traversalCostNs) {
+    public void doFrame(String focusedActivity, long startNs, long endNs, boolean isVsyncFrame, long intendedFrameTimeNs,
+                        long inputCostNs, long animationCostNs, long insetsAnimationCostNs, long traversalCostNs, long commitCostNs) {
         if (isForeground()) {
-            notifyListener(focusedActivity, startNs, endNs, isVsyncFrame, intendedFrameTimeNs, inputCostNs, animationCostNs, traversalCostNs);
+            notifyListener(focusedActivity, startNs, endNs, isVsyncFrame, intendedFrameTimeNs,
+                    inputCostNs, animationCostNs, insetsAnimationCostNs, traversalCostNs, commitCostNs);
         }
     }
 
@@ -137,8 +139,8 @@ public class FrameTracer extends Tracer implements Application.ActivityLifecycle
         return durationSum;
     }
 
-    private void notifyListener(final String focusedActivity, final long startNs, final long endNs, final boolean isVsyncFrame,
-                                final long intendedFrameTimeNs, final long inputCostNs, final long animationCostNs, final long traversalCostNs) {
+    private void notifyListener(final String focusedActivity, final long startNs, final long endNs, final boolean isVsyncFrame, final long intendedFrameTimeNs,
+                                final long inputCostNs, final long animationCostNs, final long insetsAnimationCostNs, final long traversalCostNs, final long commitCostNs) {
         long traceBegin = System.currentTimeMillis();
         try {
             final long jitter = endNs - intendedFrameTimeNs;
@@ -167,19 +169,19 @@ public class FrameTracer extends Tracer implements Application.ActivityLifecycle
                     if (null != listener.getExecutor()) {
                         if (listener.getIntervalFrameReplay() > 0) {
                             listener.collect(focusedActivity, startNs, endNs, dropFrame, isVsyncFrame,
-                                    intendedFrameTimeNs, inputCostNs, animationCostNs, traversalCostNs);
+                                    intendedFrameTimeNs, inputCostNs, animationCostNs, insetsAnimationCostNs, traversalCostNs, commitCostNs);
                         } else {
                             listener.getExecutor().execute(new Runnable() {
                                 @Override
                                 public void run() {
                                     listener.doFrameAsync(focusedActivity, startNs, endNs, dropFrame, isVsyncFrame,
-                                            intendedFrameTimeNs, inputCostNs, animationCostNs, traversalCostNs);
+                                            intendedFrameTimeNs, inputCostNs, animationCostNs, insetsAnimationCostNs, traversalCostNs, commitCostNs);
                                 }
                             });
                         }
                     } else {
                         listener.doFrameSync(focusedActivity, startNs, endNs, dropFrame, isVsyncFrame,
-                                intendedFrameTimeNs, inputCostNs, animationCostNs, traversalCostNs);
+                                intendedFrameTimeNs, inputCostNs, animationCostNs, insetsAnimationCostNs, traversalCostNs, commitCostNs);
                     }
 
                     if (config.isDevEnv()) {
@@ -379,7 +381,7 @@ public class FrameTracer extends Tracer implements Application.ActivityLifecycle
                     long vsynTime = frameMetricsCopy.getMetric(FrameMetrics.VSYNC_TIMESTAMP);
                     long intendedVsyncTime = frameMetricsCopy.getMetric(FrameMetrics.INTENDED_VSYNC_TIMESTAMP);
                     frameMetricsCopy.getMetric(FrameMetrics.DRAW_DURATION);
-                    notifyListener(AppActiveMatrixDelegate.INSTANCE.getVisibleScene(), intendedVsyncTime, vsynTime, true, intendedVsyncTime, 0, 0, 0);
+                    notifyListener(AppActiveMatrixDelegate.INSTANCE.getVisibleScene(), intendedVsyncTime, vsynTime, true, intendedVsyncTime, 0, 0, 0, 0, 0);
                 }
             };
             this.frameListenerMap.put(activity.hashCode(), onFrameMetricsAvailableListener);

--- a/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/view/FrameDecorator.java
+++ b/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/view/FrameDecorator.java
@@ -204,8 +204,10 @@ public class FrameDecorator extends IDoFrameListener implements IAppForeground {
 
 
     @Override
-    public void doFrameAsync(String focusedActivity, long startNs, long endNs, int dropFrame, boolean isVsyncFrame, long intendedFrameTimeNs, long inputCostNs, long animationCostNs, long traversalCostNs) {
-        super.doFrameAsync(focusedActivity, startNs, endNs, dropFrame, isVsyncFrame, intendedFrameTimeNs, inputCostNs, animationCostNs, traversalCostNs);
+    public void doFrameAsync(String focusedActivity, long startNs, long endNs, int dropFrame, boolean isVsyncFrame, long intendedFrameTimeNs,
+                             long inputCostNs, long animationCostNs, long insetsAnimationCostNs, long traversalCostNs, long commitCostNs) {
+        super.doFrameAsync(focusedActivity, startNs, endNs, dropFrame, isVsyncFrame, intendedFrameTimeNs,
+                inputCostNs, animationCostNs, insetsAnimationCostNs, traversalCostNs, commitCostNs);
 
         if (!Objects.equals(focusedActivity, lastVisibleScene)) {
             dropLevel = new int[FrameTracer.DropStatus.values().length];


### PR DESCRIPTION
在vsync到来时，UIThreadMonitor仅支持CALLBACK_INPUT = 0，CALLBACK_ANIMATION = 1，CALLBACK_TRAVERSAL = 2这三种类型，而从Android 6.0开始，就新增了类型CALLBACK_COMMIT = 3，在Android 10.0开始，又新增了CALLBACK_INSETS_ANIMATION。
本PR在UIThreadMonitor中对当前所有Android系统做出兼容处理，使得UIThreadMonitor中的数据与Choreographer保持一致。