### PR TITLE
修复FrameDecorator无权限时自动显示时崩溃问题

### DIFF
--- a/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/view/FrameDecorator.java
+++ b/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/view/FrameDecorator.java
@@ -53,6 +53,7 @@ public class FrameDecorator extends IDoFrameListener implements IAppForeground {
     private WindowManager windowManager;
     private WindowManager.LayoutParams layoutParam;
     private boolean isShowing;
+    private boolean isBeforeDismissShowing;
     private FloatFrameView view;
     private static Handler mainHandler = new Handler(Looper.getMainLooper());
     private Handler handler;
@@ -463,8 +464,12 @@ public class FrameDecorator extends IDoFrameListener implements IAppForeground {
                 @Override
                 public void run() {
                     if (isForeground) {
-                        show();
+                        if (isBeforeDismissShowing) {
+                            isBeforeDismissShowing = false;
+                            show();
+                        }
                     } else {
+                        isBeforeDismissShowing = isShowing;
                         dismiss();
                     }
                 }


### PR DESCRIPTION
### 问题描述
在没有开启“在其他应用上层显示”权限的情况下，如果创建FrameDecorator对象，然后再去跳转到权限开启界面，不开开启权限直接返回，应用会崩溃。
比如示例app（sample-android）中点击打开`TestTraceMainActivity`，会自动跳转到开启权限页面，然后直接返回，应用就会崩溃。
```
    --------- beginning of crash
2022-02-14 16:17:32.016 31777-31777/sample.tencent.matrix E/AndroidRuntime: FATAL EXCEPTION: main
    Process: sample.tencent.matrix, PID: 31777
    android.view.WindowManager$BadTokenException: Unable to add window android.view.ViewRootImpl$W@b57a8f -- permission denied for window type 2038
        at android.view.ViewRootImpl.setView(ViewRootImpl.java:1219)
        at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:469)
        at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:130)
        at com.tencent.matrix.trace.view.FrameDecorator$7.run(FrameDecorator.java:420)
        at android.os.Handler.handleCallback(Handler.java:900)
        at android.os.Handler.dispatchMessage(Handler.java:103)
        at android.os.Looper.loop(Looper.java:219)
        at android.app.ActivityThread.main(ActivityThread.java:8668)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1109)
```

测试手机：华为nova6
系统版本：HarmonyOS 2.0.0
matrix版本：2.0.5

### 修复建议
FrameDecorator仅在切换到后台之前是显示的，再切换到前台才会恢复显示状态
