### PR TITLE
fixBug:android8.0以下获取帧率为0

### DIFF
--- a/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/tracer/FrameTracer.java
+++ b/matrix/matrix-android/matrix-trace-canary/src/main/java/com/tencent/matrix/trace/tracer/FrameTracer.java
@@ -270,7 +270,7 @@ public class FrameTracer extends Tracer implements Application.ActivityLifecycle
 
     private class FrameCollectItem {
         String visibleScene;
-        long sumFrameCost;
+        float sumFrameCost;
         int sumFrame = 0;
         int sumDroppedFrames;
         // record the level of frames dropped each time
@@ -306,7 +306,7 @@ public class FrameTracer extends Tracer implements Application.ActivityLifecycle
         }
 
         void report() {
-            float fps = Math.min(refreshRate, 1000.f * sumFrame / sumFrameCost);
+            float fps = 1000.f * sumFrame / sumFrameCost;
             MatrixLog.i(TAG, "[report] FPS:%s %s", fps, toString());
             try {
                 TracePlugin plugin = Matrix.with().getPluginByClass(TracePlugin.class);


### PR DESCRIPTION
refreshRate只在useFrameMetrics为true(Android8.0以上)初始化，Android8.0以下为默认值0，从而导致获取的帧率为0