### PR TITLE
fix android sample compile error

### DIFF
--- a/samples/sample-android/app/dependencies-aar.gradle
+++ b/samples/sample-android/app/dependencies-aar.gradle
@@ -27,6 +27,7 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:1.1.0"
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'com.tencent:mmkv:1.2.14'
 
     implementation(project(':libkt'))
 

--- a/samples/sample-android/libkt/build.gradle
+++ b/samples/sample-android/libkt/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
     api "com.tencent.matrix:matrix-memory-canary:${MATRIX_VERSION}"
+    api "com.tencent.matrix:matrix-android-lib:${MATRIX_VERSION}"
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
Maybe developers in Tencent use local project dependencies so that there is still compile error for aar dependencies.