### PR TITLE
Fix app_uuid may be empty in the report 修复报告中 app_uuid 可能为空的问题

### DIFF
--- a/matrix/matrix-iOS/Matrix/WCMemoryStat/MemoryLogger/StackFrames/bundle_name_helper.mm
+++ b/matrix/matrix-iOS/Matrix/WCMemoryStat/MemoryLogger/StackFrames/bundle_name_helper.mm
@@ -22,7 +22,7 @@ void bundleHelperGetAppBundleName(char *outBuffer, unsigned int bufferSize) {
         return;
     }
 
-    NSString *bundleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+    NSString *bundleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleExecutable"];
     if (bundleName) {
         const char *cStr = [[NSString stringWithFormat:@"/%@.app/", bundleName] cStringUsingEncoding:NSUTF8StringEncoding];
         strncpy(outBuffer, cStr, bufferSize);
@@ -37,7 +37,7 @@ void bundleHelperGetAppName(char *outBuffer, unsigned int bufferSize) {
         return;
     }
 
-    NSString *bundleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+    NSString *bundleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleExecutable"];
     if (bundleName) {
         const char *cStr = [[NSString stringWithFormat:@"/%@.app/%@", bundleName, bundleName] cStringUsingEncoding:NSUTF8StringEncoding];
         strncpy(outBuffer, cStr, bufferSize);


### PR DESCRIPTION
原因：
当前使用 CFBundleName 构造 app name 和 app bundle name，但 CFBundleName 是支持多语言配置的，不同语言环境下读到的结果可能会不同；此时跟 image_info.dli_fname 做值比对时就不会认为是同一个，导致找不到当前 app image

修复方案：
app name 和 app bundle name 使用 CFBundleExecutable 来获取二进制名，排除多语言环境的影响