### PR TITLE
Add proguard rules for native referenced methods in matrix trace canary library

### DIFF
--- a/matrix/matrix-android/matrix-trace-canary/proguard-rules.pro
+++ b/matrix/matrix-android/matrix-trace-canary/proguard-rules.pro
@@ -1,2 +1,11 @@
 
 -keep class com.tencent.matrix.trace.core.AppMethodBeat { *; }
+-keep class com.tencent.matrix.trace.tracer.SignalAnrTracer {
+    native <methods>;
+}
+-keep class com.tencent.matrix.trace.tracer.ThreadTracer {
+    native <methods>;
+}
+-keep class com.tencent.matrix.trace.tracer.TouchEventLagTracer {
+    native <methods>;
+}


### PR DESCRIPTION
There are some missing proguard rules for the trace canary library. Some Java class and method names are called from native c++ code, MatrixTracer.cc in specific. So we need to explicit keep those names in proguard, otherwise there will be errors like "java.lang.UnsatisfiedLinkError: JNI_ERR returned from JNI_OnLoad" at the host app side when loading the SO file. 